### PR TITLE
Use .then in example instead of finally

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,12 @@ Using `Promise.allSettled` would be more suitable for the operation we wish to p
 
 ```js
 // We know all API calls have finished.
-Promise.allSettled(requests).then(() => {
-  console.log('All requests are completed: either failed or succeeded, I don’t care');
-  removeLoadingIndicator();
-});
+Promise.allSettled(requests)
+  .catch(() => console.log('Unreachable as allSettled never rejects.'))
+  .finally(() => {
+    console.log('All requests are completed: either failed or succeeded, I don’t care');
+    removeLoadingIndicator();
+  });
 ```
 
 ## Userland implementations

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Using `Promise.allSettled` would be more suitable for the operation we wish to p
 
 ```js
 // We know all API calls have finished.
-Promise.allSettled(requests).finally(() => {
+Promise.allSettled(requests).then(() => {
   console.log('All requests are completed: either failed or succeeded, I don’t care');
   removeLoadingIndicator();
 });

--- a/README.md
+++ b/README.md
@@ -87,13 +87,11 @@ try {
 Using `Promise.allSettled` would be more suitable for the operation we wish to perform:
 
 ```js
-// We know all API calls have finished.
-Promise.allSettled(requests)
-  .catch(() => console.log('Unreachable as allSettled never rejects.'))
-  .finally(() => {
-    console.log('All requests are completed: either failed or succeeded, I don’t care');
-    removeLoadingIndicator();
-  });
+// We know all API calls have finished. We use finally but allSettled will never throw.
+Promise.allSettled(requests).finally(() => {
+  console.log('All requests are completed: either failed or succeeded, I don’t care');
+  removeLoadingIndicator();
+});
 ```
 
 ## Userland implementations

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ try {
 Using `Promise.allSettled` would be more suitable for the operation we wish to perform:
 
 ```js
-// We know all API calls have finished. We use finally but allSettled will never throw.
+// We know all API calls have finished. We use finally but allSettled will never reject.
 Promise.allSettled(requests).finally(() => {
   console.log('All requests are completed: either failed or succeeded, I don’t care');
   removeLoadingIndicator();


### PR DESCRIPTION
Updates the example to use .then instead of .finally after an allSettled Promise. Makes it clearer that there is no way that allSettled can reject.