### PR TITLE
Optimize constructor.resolve lookup

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -38,8 +38,7 @@ contributors: Jason Williams, Robert Pamely, Mathias Bynens
         1. Let _values_ be a new empty List.
         1. Let _remainingElementsCount_ be a new Record { [[Value]]: 1 }.
         1. Let _index_ be 0.
-        1. Let _promiseResolve_ be Get(_constructor_, `"resolve"`).
-        1. ReturnIfAbrupt(_promiseResolve_).
+        1. Let _promiseResolve_ be ? GetMethod(_constructor_, `"resolve"`).
         1. Repeat,
           1. Let _next_ be IteratorStep(_iteratorRecord_).
           1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.

--- a/spec.html
+++ b/spec.html
@@ -38,7 +38,8 @@ contributors: Jason Williams, Robert Pamely, Mathias Bynens
         1. Let _values_ be a new empty List.
         1. Let _remainingElementsCount_ be a new Record { [[Value]]: 1 }.
         1. Let _index_ be 0.
-        1. Let _promiseResolve_ be ? GetMethod(_constructor_, `"resolve"`).
+        1. Let _promiseResolve_ be ? Get(_constructor_, `"resolve"`).
+        1. If IsCallable(_promiseResolve_) is *false*, throw a *TypeError* exception.
         1. Repeat,
           1. Let _next_ be IteratorStep(_iteratorRecord_).
           1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.

--- a/spec.html
+++ b/spec.html
@@ -38,6 +38,8 @@ contributors: Jason Williams, Robert Pamely, Mathias Bynens
         1. Let _values_ be a new empty List.
         1. Let _remainingElementsCount_ be a new Record { [[Value]]: 1 }.
         1. Let _index_ be 0.
+        1. Let _promiseResolve_ be Get(_constructor_, `"resolve"`).
+        1. ReturnIfAbrupt(_promiseResolve_).
         1. Repeat,
           1. Let _next_ be IteratorStep(_iteratorRecord_).
           1. If _next_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
@@ -53,7 +55,7 @@ contributors: Jason Williams, Robert Pamely, Mathias Bynens
           1. If _nextValue_ is an abrupt completion, set _iteratorRecord_.[[Done]] to *true*.
           1. ReturnIfAbrupt(_nextValue_).
           1. Append *undefined* to _values_.
-          1. Let _nextPromise_ be ? Invoke(_constructor_, `"resolve"`, &laquo; _nextValue_ &raquo;).
+          1. Let _nextPromise_ be ? Call(_promiseResolve_, _constructor_, &laquo; _nextValue_ &raquo;).
           1. Let _steps_ be the algorithm steps defined in <emu-xref href="#sec-promise.allsettled-resolve-element-functions" title></emu-xref>.
           1. Let _resolveElement_ be ! CreateBuiltinFunction(_steps_, &laquo; [[AlreadyCalled]], [[Index]], [[Values]], [[Capability]], [[RemainingElements]] &raquo;).
           1. Let _alreadyCalled_ be a new Record { [[Value]]: *false* }.


### PR DESCRIPTION
To optimize away the `Get` and `Call` of the `resolve` method on the `constructor`, I'd have to check the `constructor` to see if its `resolve` method has been modified or not. If it's not been modified, I can directly call (or even inline) the builtin `%PromiseResolve%`, saving the lookup and call overhead for faster performance.

Without this patch, I would have to check against the `constructor` for every iteration of the loop before going to the fast path.

With this patch, I can do a check against the `constructor` just once at the beginning.

The change in behavior with this patch is that if you modify the constructor's `resolve` property in the middle of iterating the iterable argument, then it is not observed. I don't think anyone should do this in any case as it's surprising side-effecting behavior.